### PR TITLE
highlighting org membership request from contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,10 @@ Here you'll find details on how to contribute AI quickstarts!
 * [How are quickstarts maintained?](#how-are-quickstarts-maintained)
 * [How are AI quickstarts organized?](#how-are-ai-quickstarts-organized)
 * [What are the repository requirements?](#what-are-the-repository-requirements)
+* [How do I join the GitHub organization?](#how-do-i-join-the-github-organization)
 * [How do I create a new quickstart?](#how-do-i-create-a-new-quickstart)
 * [How to publish and promote your quickstart?](#how-to-publish-and-promote-your-quickstart)
-* [Can I deploy and share a working example?](#can-i-deploy-and-share-a-working-example) 
+* [Can I deploy and share a working example?](#can-i-deploy-and-share-a-working-example)
 
 
 
@@ -78,7 +79,11 @@ examples that any one can try and tell a compelling story.
 ### Optional, but encouraged
 * Add "[tags](#tag-your-quickstart)" to the About section of your quickstart 
 
-## How do I create a new quickstart? 
+## How do I join the GitHub organization?
+
+* Submit a new "Membership request" issue following the process outlined in the [user guide](user-guide.md#getting-help-submitting-feedback-and-making-requests).
+
+## How do I create a new quickstart?
 
 **1. Click "Repositories" in the [AI quickstart org](https://github.com/rh-ai-quickstart)**
 

--- a/user-guide.md
+++ b/user-guide.md
@@ -98,7 +98,7 @@ For general feedback, please create an
 If you're **ever unsure** where to submit a request, just submit an "issue" in the 
 [ai-quickstart-contrib repository](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues).
 
-### Here's how to submit a general request. 
+### Here's how to submit a request. 
 1. Navigate to [ai-quickstart-contrib](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/tree/main)
 2. Select "[Issues](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues)"
 3. Click the green "New issue" button, top right 
@@ -109,16 +109,17 @@ If you're **ever unsure** where to submit a request, just submit an "issue" in t
 
 ![rh-ai-quickstart-contrib-new-issue.png](assets/images/rh-ai-quickstart-contrib-new-issue.png)
 
+### GitHub membership
+
+To join the AI quickstart Github organization, please use the **Membership request** option 
+when creating your request. Membership allows you to create AI quickstart 
+repositories for others to use.
+
 ### Other 
 
 **Quickstart suggestion** can be used to suggest a new quickstart. Please note, all
 suggestions are welcome but there are no guarantees we'll be able to build it! 
 
-Please use **Membership request** to request official membership to the AI
-quickstart Github organization. Membership allows you to create AI quickstart
-repositories for others to use. 
 
 Use "Blank issue" for all other requests, feedback or anything else on your
-mind. 
-
-
+mind.


### PR DESCRIPTION
Attempting to make the org membership process a little easier to find when someone lands in the contributor's guide before the user guide.